### PR TITLE
mamba>=0.17 to avoid failing idempotence check

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -104,7 +104,7 @@ jobs:
           cd examples/aws-ec2
           ./ci/run-localstack.sh -d
           sleep 10
-          molecule test --scenario-name ${{ matrix.scenario }}
+          molecule --debug -vv test --scenario-name ${{ matrix.scenario }}
 
   # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-pypi:

--- a/examples/aws-ec2/jupyterhub-deploy.yml
+++ b/examples/aws-ec2/jupyterhub-deploy.yml
@@ -54,11 +54,11 @@
           - conda-forge
         name:
           - python=3.9
-          - jupyterhub=1.4
+          - jupyterhub=1.5
           - oauthenticator=14
           - ansible=4
           - ansible-runner=1.4
-          - boto3=1.18 # for Ansible AWS modules
+          - boto3=1.19 # for Ansible AWS modules
           - docker-py=5 # for Ansible Docker modules
           - shade=1.33 # for Ansible Openstack modules
           - pip=21
@@ -74,7 +74,7 @@
     - name: Install jupyterhub-ansiblespawner
       pip:
         name:
-          - git+https://github.com/manics/jupyterhub-ansiblespawner.git@5ebafeaad666d4e6843e96e2cef9ad568cbae30c
+          - git+https://github.com/manics/jupyterhub-ansiblespawner.git@5651185d187f89267717f172f2903028ef5bc257
         executable: /opt/conda/bin/pip
         state: present
 

--- a/examples/aws-ec2/jupyterhub-deploy.yml
+++ b/examples/aws-ec2/jupyterhub-deploy.yml
@@ -39,12 +39,14 @@
         channels:
           - conda-forge
         name:
-          # Use >= to avoid idempotence error if mamba is updated in a later step
-          - mamba>=0.17
+          - mamba=0.17
         # Specifying an environment makes this non-idempotent 😞
         # environment: jupyterhub
         executable: /opt/conda/bin/conda
         state: present
+      tags:
+        # Skip this task during the idempotence check 😞
+        - molecule-idempotence-notest
 
     - name: Install Jupyterhub
       conda:
@@ -65,6 +67,9 @@
         # executable: /opt/conda/envs/jupyterhub/bin/mamba
         executable: /opt/conda/bin/mamba
         state: present
+      tags:
+        # Skip this task during the idempotence check 😞
+        - molecule-idempotence-notest
 
     - name: Install jupyterhub-ansiblespawner
       pip:

--- a/examples/aws-ec2/jupyterhub-deploy.yml
+++ b/examples/aws-ec2/jupyterhub-deploy.yml
@@ -39,7 +39,8 @@
         channels:
           - conda-forge
         name:
-          - mamba=0.15
+          # Use >= to avoid idempotence error if mamba is updated in a later step
+          - mamba>=0.17
         # Specifying an environment makes this non-idempotent 😞
         # environment: jupyterhub
         executable: /opt/conda/bin/conda

--- a/examples/aws-ec2/molecule/podman-deploy/molecule.yml
+++ b/examples/aws-ec2/molecule/podman-deploy/molecule.yml
@@ -33,3 +33,6 @@ provisioner:
     converge: ../../jupyterhub-deploy.yml
 verifier:
   name: ansible
+scenario:
+  converge_sequence:
+    - converge


### PR DESCRIPTION
Use >= so that if mamba is upgraded in a later step the earlier step doesn't fail its idempotence check